### PR TITLE
Added preventOpenDuplicates global option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ app.config(function(toastrConfig) {
     onShown: null,
     positionClass: 'toast-top-right',
     preventDuplicates: false,
+    preventOpenDuplicates: false,
     progressBar: false,
     tapToDismiss: true,
     target: 'body',
@@ -163,6 +164,7 @@ Those are the default values, you can pick what you need from it and override wi
 * **onShown**: A callback function called when a toast is shown.
 * **positionClass**: The position where the toasts are added.
 * **preventDuplicates**: Prevent duplicates of the last toast.
+* **preventOpenDuplicates**: Prevent duplicates of open toasts.
 * **progressBar**: A progress bar to see the timeout in real time.
 * **tapToDismiss**: Whether the toast should be dismissed when it is clicked.
 * **target**: The element to put the toastr container.
@@ -234,7 +236,7 @@ There you can override:
 * **allowHtml**: Whether to allow HTML or not in a concrete toast.
 * **closeButton**: Putting a close button on the toast.
 * **closeHtml**: If you need to override how the close button looks like.
-* **extendedTimeout**: The timeout after you hover it.
+* **extendedTimeOut**: The timeout after you hover it.
 * **iconClass**: For the type class you want to use for the toast.
 * **messageClass**: If you want to modify the message look.
 * **onHidden**: Function to call when the toast gets hidden.

--- a/src/toastr.js
+++ b/src/toastr.js
@@ -12,6 +12,7 @@
     var toasts = [];
 
     var previousToastMessage = '';
+    var openToasts = {};
 
     var containerDefer = $q.defer();
 
@@ -69,6 +70,7 @@
           }
           toast.scope.$destroy();
           var index = toasts.indexOf(toast);
+          delete openToasts[toast.scope.message];
           toasts.splice(index, 1);
           var maxOpened = toastrConfig.maxOpened;
           if (maxOpened && toasts.length >= maxOpened) {
@@ -225,7 +227,7 @@
 
         function cleanOptionsOverride(options) {
           var badOptions = ['containerId', 'iconClasses', 'maxOpened', 'newestOnTop',
-                            'positionClass', 'preventDuplicates', 'templates'];
+                            'positionClass', 'preventDuplicates', 'preventOpenDuplicates', 'templates'];
           for (var i = 0, l = badOptions.length; i < l; i++) {
             delete options[badOptions[i]];
           }
@@ -245,14 +247,21 @@
       }
 
       function shouldExit() {
-        if (options.preventDuplicates) {
-          if (map.message === previousToastMessage) {
-            return true;
-          } else {
-            previousToastMessage = map.message;
-          }
-          return false;
+        var isDuplicateOfLast = options.preventDuplicates && map.message === previousToastMessage;
+        var isDuplicateOpen = options.preventOpenDuplicates && openToasts[map.message];
+
+        if (isDuplicateOfLast) {
+          return true;
         }
+
+        if (isDuplicateOpen) {
+          return true;
+        }
+
+        previousToastMessage = map.message;
+        openToasts[map.message] = true;
+
+        return false;
       }
     }
   }

--- a/src/toastr.js
+++ b/src/toastr.js
@@ -250,11 +250,7 @@
         var isDuplicateOfLast = options.preventDuplicates && map.message === previousToastMessage;
         var isDuplicateOpen = options.preventOpenDuplicates && openToasts[map.message];
 
-        if (isDuplicateOfLast) {
-          return true;
-        }
-
-        if (isDuplicateOpen) {
+        if (isDuplicateOfLast || isDuplicateOpen) {
           return true;
         }
 

--- a/test/toastr_spec.js
+++ b/test/toastr_spec.js
@@ -517,6 +517,23 @@ describe('toastr', function() {
       expect($document).toHaveToastOpen(0);
     });
 
+    it('can prevent duplicate of open toasts', function() {
+      toastrConfig.preventDuplicates = false;
+      toastrConfig.preventOpenDuplicates = true;
+      var toast1 = openToast('success', 'Toast 1');
+      var toast2 = openToast('success', 'Toast 2');
+      openToast('success', 'Toast 1');
+      openToast('success', 'Toast 2');
+      var toast3 = openToast('success', 'Toast 3');
+      openToast('success', 'Toast 1');
+      expect($document).toHaveToastOpen(3);
+      removeToast(toast1);
+      removeToast(toast2);
+      removeToast(toast3);
+      openToast('success', 'Toast 1');
+      expect($document).toHaveToastOpen(1);
+    });
+
     it('does not merge options not meant for concrete toasts', function() {
       openToasts(2, {
         maxOpened: 2 // this is not meant for the toasts and gives weird side effects


### PR DESCRIPTION
The option prevents toasts that are currently open from having duplicates.
Also fixed typo in documentation: extendedTimeOut.

The current `preventDuplicates` option does not suit my needs. For example, if I displayed a toast after a request error and it timed out, I want the toast to be displayed again if it reoccurs.