### PR TITLE
Added support for Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./dist/angular-toastr.tpls.js');
+module.exports = 'toastr';
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/Foxandxss/angular-toastr.git"
   },
-  "main": "dist/angular-toastr.tpls.js",
+  "main": "index.js",
   "keywords": [
     "angularjs",
     "toastr",


### PR DESCRIPTION
Added `toastr` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

```angular.module('myApp', [require('angular-toastr')]);```

This is helpful for Browserify and Webpack.