### PR TITLE
Added aria-labels to toast titles and messages

### DIFF
--- a/src/directives/toast/toast.html
+++ b/src/directives/toast/toast.html
@@ -1,7 +1,7 @@
 <div class="{{toastClass}} {{toastType}}" ng-click="tapToast()">
   <div ng-switch on="allowHtml">
-    <div ng-switch-default ng-if="title" class="{{titleClass}}">{{title}}</div>
-    <div ng-switch-default class="{{messageClass}}">{{message}}</div>
+    <div ng-switch-default ng-if="title" class="{{titleClass}}" aria-label="{{title}}">{{title}}</div>
+    <div ng-switch-default class="{{messageClass}}" aria-label="{{message}}">{{message}}</div>
     <div ng-switch-when="true" ng-if="title" class="{{titleClass}}" ng-bind-html="title"></div>
     <div ng-switch-when="true" class="{{messageClass}}" ng-bind-html="message"></div>
   </div>

--- a/test/toastr_spec.js
+++ b/test/toastr_spec.js
@@ -65,6 +65,16 @@ describe('toastr', function() {
         return title.length === 1;
       },
 
+      toHaveAriaLabelOnTitle: function() {
+        var title = this.actual.el.find('.toast-title');
+        return title.is("[aria-label]");
+      },
+
+      toHaveAriaLabelOnMessage: function() {
+        var message = this.actual.el.find('.toast-message');
+        return message.is("[aria-label]");
+      },
+
       toHaveType: function(type) {
         var typeClass = 'toast-' + type;
         return this.actual.el.hasClass(typeClass);
@@ -406,6 +416,12 @@ describe('toastr', function() {
       };
       var toast = openToast('error', 'message', 'title', options);
       expect(toast).toHaveClass(options.toastClass);
+    });
+
+    it('title and message should contain aria-label', function() {
+      var toast = openToast('error', 'message', 'title');
+      expect(toast).toHaveAriaLabelOnMessage();
+      expect(toast).toHaveAriaLabelOnTitle();
     });
 
     it('can make a toast stick until is clicked or hovered (extended timeout)', function() {


### PR DESCRIPTION
In compliance with http://en.wikipedia.org/wiki/Assistive_technology to the benefit of the disabled or partially disabled people `<div>` elements representing toast's *title* and *message* should be accompanied with an aria-label attribute parsed by the screen readers.