### PR TITLE
The proposed change fixes TypeError: newToast.scope.init is not a fun…

### DIFF
--- a/src/toastr.js
+++ b/src/toastr.js
@@ -4,9 +4,9 @@
   angular.module('toastr', [])
     .factory('toastr', toastr);
 
-  toastr.$inject = ['$animate', '$injector', '$document', '$rootScope', '$sce', 'toastrConfig', '$q'];
+  toastr.$inject = ['$animate', '$injector', '$document', '$rootScope', '$sce', 'toastrConfig', '$q', '$timeout'];
 
-  function toastr($animate, $injector, $document, $rootScope, $sce, toastrConfig, $q) {
+  function toastr($animate, $injector, $document, $rootScope, $sce, toastrConfig, $q, $timeout) {
     var container;
     var index = 0;
     var toasts = [];
@@ -170,12 +170,16 @@
           newToast.isOpened = true;
           if (options.newestOnTop) {
             $animate.enter(newToast.el, container).then(function() {
-              newToast.scope.init();
+              $timeout(function(){
+                  newToast.scope.init();
+              });
             });
           } else {
             var sibling = container[0].lastChild ? angular.element(container[0].lastChild) : null;
             $animate.enter(newToast.el, container, sibling).then(function() {
-              newToast.scope.init();
+                 $timeout(function(){
+                  newToast.scope.init();
+              });
             });
           }
         });


### PR DESCRIPTION
…ction Error

The type error is caused after the first toast is created upon the second and subsequent toasts being created. It occurs because you are not guaranteed that the directive link function has not been fully executed creating the scope.init function. 

By using the $timeout,you are ensuring that the call to use scope.init will occur after the previously queued digest requests have been completed. 

This was verified in angular 1.5.3. and also is not necessary related to the template caching as we repro this using the builtin tpls file.