### PR TITLE
Preserve `margin-bottom` of each toasts.

### DIFF
--- a/src/toastr.less
+++ b/src/toastr.less
@@ -169,13 +169,15 @@ button.toast-close-button {
   &.toast-top-center .toast,
   &.toast-bottom-center .toast {
     width: 300px;
-    margin: auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   &.toast-top-full-width .toast,
   &.toast-bottom-full-width .toast {
     width: 96%;
-    margin: auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
`margin: auto;` overrides `margin: 0 0 6px;` of each toasts.
I replaced this with `margin-left` and `margin-right` properties.

It was also [implemented at the original toastr](https://github.com/CodeSeven/toastr/commit/0fdcc900be6a1bde7444e71f1c7b87bddabc7ca7).

**CAUTION: I didn't touch css files under `/dist` directory so that still has the problem.**