### PR TITLE
Unused reference to $document destroyes uglification

### DIFF
--- a/dist/angular-toastr.js
+++ b/dist/angular-toastr.js
@@ -4,9 +4,9 @@
   angular.module('toastr', [])
     .factory('toastr', toastr);
 
-  toastr.$inject = ['$animate', '$injector', '$document', '$rootScope', '$sce', 'toastrConfig', '$q'];
+  toastr.$inject = ['$animate', '$injector', '$rootScope', '$sce', 'toastrConfig', '$q'];
 
-  function toastr($animate, $injector, $document, $rootScope, $sce, toastrConfig, $q) {
+  function toastr($animate, $injector, $rootScope, $sce, toastrConfig, $q) {
     var container;
     var index = 0;
     var toasts = [];

--- a/dist/angular-toastr.tpls.js
+++ b/dist/angular-toastr.tpls.js
@@ -4,9 +4,9 @@
   angular.module('toastr', [])
     .factory('toastr', toastr);
 
-  toastr.$inject = ['$animate', '$injector', '$document', '$rootScope', '$sce', 'toastrConfig', '$q'];
+  toastr.$inject = ['$animate', '$injector', '$rootScope', '$sce', 'toastrConfig', '$q'];
 
-  function toastr($animate, $injector, $document, $rootScope, $sce, toastrConfig, $q) {
+  function toastr($animate, $injector, $rootScope, $sce, toastrConfig, $q) {
     var container;
     var index = 0;
     var toasts = [];

--- a/src/toastr.js
+++ b/src/toastr.js
@@ -4,9 +4,9 @@
   angular.module('toastr', [])
     .factory('toastr', toastr);
 
-  toastr.$inject = ['$animate', '$injector', '$document', '$rootScope', '$sce', 'toastrConfig', '$q'];
+  toastr.$inject = ['$animate', '$injector', '$rootScope', '$sce', 'toastrConfig', '$q'];
 
-  function toastr($animate, $injector, $document, $rootScope, $sce, toastrConfig, $q) {
+  function toastr($animate, $injector, $rootScope, $sce, toastrConfig, $q) {
     var container;
     var index = 0;
     var toasts = [];


### PR DESCRIPTION
My build script is using uglification to concatenate and minify all third party dependencies but this did not work when including toastr.js or toastr.tpl.js. The uglification is removing unused references from the code which then breaks the dependency injection in angular.

And since `$document` is unused anyway I saw no reason not to simply remove it?